### PR TITLE
Fix histogram display for residuals in plotting functions

### DIFF
--- a/R/angular.R
+++ b/R/angular.R
@@ -318,7 +318,12 @@ print.summary.angular <- function(x, ...) {
   cat("Residuals:\n")
   print(x$residuals)
   cat("\nParameters:\n")
-  stats::printCoefmat(x$parameters, signif.legend = TRUE, ...)
+  stats::printCoefmat(
+    x$parameters,
+    signif.stars = TRUE,
+    signif.legend = TRUE,
+    ...
+  )
   cat("\nNumber of observations:", x$nobs, "\n")
   invisible(x)
 }
@@ -352,7 +357,7 @@ plot.angular <- function(x, ...) {
     ggplot2::geom_hline(ggplot2::aes(yintercept = 0), linetype = "dashed") +
     ggplot2::labs(title = "Residuals vs Fitted", x = "Fitted Values", y = "Residuals")
 
-  res <- residuals.angular(x)
+  res <- as.numeric(residuals.angular(x))
   res_mean <- mean(res)
   res_sd <- stats::sd(res)
   p2 <- ggplot2::ggplot(data = data.frame(Residual = res),

--- a/R/consensus.R
+++ b/R/consensus.R
@@ -343,7 +343,12 @@ print.summary.consensus <- function(x, ...) {
   cat("Residuals:\n")
   print(x$residuals)
   cat("\nCoefficients:\n")
-  stats::printCoefmat(x$coefficients, signif.legend = TRUE, ...)
+  stats::printCoefmat(
+    x$coefficients,
+    signif.stars = TRUE,
+    signif.legend = TRUE,
+    ...
+  )
   cat("\nNumber of observations:", x$nobs, "\n")
   invisible(x)
 }
@@ -378,7 +383,7 @@ plot.consensus <- function(x, ...) {
     ggplot2::geom_hline(ggplot2::aes(yintercept = 0), linetype = "dashed") +
     ggplot2::labs(title = "Residuals vs Fitted", x = "Fitted Values", y = "Residuals")
 
-  res <- residuals.consensus(x, ...)
+  res <- as.numeric(residuals.consensus(x, ...))
   res_mean <- mean(res)
   res_sd <- stats::sd(res)
   p2 <- ggplot2::ggplot(data = data.frame(Residual = res),


### PR DESCRIPTION
## Summary
- ensure residuals are numeric before plotting histograms in `plot.angular` and `plot.consensus`
- print significance stars when summarizing angular and consensus fits

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866717e2ce08322b1cff778363cd715