### PR TITLE
Add non-parametric variance for angular model and simplify consensus outputs

### DIFF
--- a/man/angular.Rd
+++ b/man/angular.Rd
@@ -29,8 +29,7 @@ An object of class "angular" containing:
   \item{MaxCosine}{the maximum cosine value.}
   \item{parameters}{the parameter estimates and their standard errors, z-values and associated p-values.}
   \item{varcov0}{the estimated variance-covariance matrix (first definition).}
-  \item{varcov1}{the estimated variance-covariance matrix (second definition).}
-  \item{autocorr}{the autocorrelation of the residuals \eqn{\sin(y_i - \mu_i)}.}
+  \item{varcov2}{the non-parametric estimated variance-covariance matrix (equation 14 of Rivest et al.).}
   \item{long}{the vector of predicted concentrations.}
   \item{mui}{the vector of predicted mean angles.}
   \item{y}{the response variable.}

--- a/man/consensus.Rd
+++ b/man/consensus.Rd
@@ -45,12 +45,10 @@ An object of class "consensus" containing:
   \item{MaxLL}{the maximum value of the log likelihood.}
   \item{AIC}{the Akaike Information Criterion.}
   \item{BIC}{the Bayesian Information Criterion.}
-  \item{parameters}{the parameter estimates and their robust standard errors, z-values and associated p-values.}
-  \item{varcov1}{the estimated variance covariance matrix (first definition).}
-  \item{varcov2}{the estimated variance covariance matrix (second definition).}
+  \item{parameters}{the parameter estimates and their standard errors, z-values and associated p-values.}
+  \item{varcov1}{the estimated variance covariance matrix.}
   \item{parambeta}{the beta parameter estimates and their standard errors (obtained by linearization).}
   \item{varcovbeta1}{the estimated variance covariance matrix for the beta estimates (by linearization).}
-  \item{varcovbeta2}{the estimated variance covariance matrix for the beta estimates (sandwich form).}
   \item{autocorr}{the autocorrelation of the residuals \eqn{\sin(y_i - \mu_i)}.}
   \item{iter.detail}{the iteration details.}
   \item{call}{the function call.}


### PR DESCRIPTION
## Summary
- add the non-parametric variance–covariance estimator described in Rivest et al. (equation 14) to `angular()` and remove the unused autocorrelation output
- keep a single variance–covariance estimate in `consensus()` and align the reported standard errors and documentation with the updated output
- refresh the reference documentation to describe the new return values

## Testing
- Rscript -e "invisible(lapply(list.files('R', full.names = TRUE), source))" *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68daf3f0e048832294c05a9283736c2d