### PR TITLE
Use bison examples and add overview vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,11 @@ Imports:
     ggplot2,
     gridExtra,
     circular
-Depends: 
+Depends:
     R (>= 3.5)
+Suggests:
+    knitr,
+    rmarkdown
+VignetteBuilder: knitr
 URL: https://github.com/AurelienNicosiaULaval/CircularRegression
 BugReports: https://github.com/AurelienNicosiaULaval/CircularRegression/issues

--- a/R/angular.R
+++ b/R/angular.R
@@ -47,13 +47,9 @@
 #' @references L.-P. Rivest, T. Duchesne, A. Nicosia & D. Fortin. A general angular regression model for the analysis of data on animal movement in ecology. Journal of the Royal Statistical Society, series C, to appear.
 #' @examples
 #' \dontrun{
-#'   # Example with fictitious data
-#'   data(wind)
-#'   n <- length(wind)
-#'   dat.hom <- data.frame(wind.t = wind[-c(1,2)],
-#'                         wind.t_1 = wind[-c(1, n)],
-#'                         wind.t_2 = wind[-c(n-1, n)])
-#'   an <- angular(wind.t ~ wind.t_1 + wind.t_2, data = dat.hom)
+#'   # Example with the bison data set included in the package
+#'   data(bison)
+#'   an <- angular(y.dir ~ y.prec + y.prec2, data = bison)
 #'   print(an)
 #'   summary(an)
 #'   plot(an)

--- a/R/consensus.R
+++ b/R/consensus.R
@@ -42,6 +42,13 @@
 #' }
 #'
 #' @author Sophie Baillargeon, Louis-Paul Rivest, and Aurélien Nicosia
+#' @examples
+#' \dontrun{
+#'   data(bison)
+#'   fit <- consensus(y.dir ~ y.prec + y.prec2, data = bison)
+#'   print(fit)
+#'   summary(fit)
+#' }
 #' @export
 consensus <- function(
   formula,

--- a/man/angular.Rd
+++ b/man/angular.Rd
@@ -55,13 +55,9 @@ The control argument is a list that can supply any of the following components:
 }
 \examples{
 \dontrun{
-  # Example with fictitious data
-  data(wind)
-  n <- length(wind)
-  dat.hom <- data.frame(wind.t = wind[-c(1,2)],
-                        wind.t_1 = wind[-c(1, n)],
-                        wind.t_2 = wind[-c(n-1, n)])
-  an <- angular(wind.t ~ wind.t_1 + wind.t_2, data = dat.hom)
+  # Example with the bison data set included in the package
+  data(bison)
+  an <- angular(y.dir ~ y.prec + y.prec2, data = bison)
   print(an)
   summary(an)
   plot(an)

--- a/man/consensus.Rd
+++ b/man/consensus.Rd
@@ -58,6 +58,14 @@ An object of class "consensus" containing:
 Function that fits a consensus model for angular variables along with its print,
 summary, and diagnostic plot methods.
 }
+\examples{
+\dontrun{
+  data(bison)
+  fit <- consensus(y.dir ~ y.prec + y.prec2, data = bison)
+  print(fit)
+  summary(fit)
+}
+}
 \author{
 Sophie Baillargeon, Louis-Paul Rivest, and Aurélien Nicosia
 }

--- a/vignettes/CircularRegression-overview.Rmd
+++ b/vignettes/CircularRegression-overview.Rmd
@@ -1,0 +1,101 @@
+---
+title: "Getting Started with CircularRegression"
+author: "CircularRegression Team"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Getting Started with CircularRegression}
+  %\VignetteEngine{knitr::rmarkdown}
+  \usepackage[utf8]{inputenc}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+# Introduction
+
+`CircularRegression` provides tools to fit regression models designed for circular
+responses. This vignette introduces the main functionality of the package using
+the `bison` data set included with the package. The demonstrations highlight
+how to fit and interpret both the angular and consensus regression models.
+
+# Loading the package and data
+
+```{r load-data}
+library(CircularRegression)
+
+data(bison)
+str(bison)
+```
+
+The `bison` data frame contains directional observations (`y.dir`) along with
+predictor summaries (`y.prec` and `y.prec2`) that characterize preceding animal
+headings. The formulas used in this vignette follow the convention of placing the
+circular response on the left-hand side.
+
+# Angular regression model
+
+The angular regression model links the response direction to previous directions
+through trigonometric transformations. The example below fits the simplified
+angular regression model with `y.dir` as the response and two predictors that
+capture previous movement directions.
+
+```{r angular-fit}
+ang_fit <- angular(y.dir ~ y.prec + y.prec2, data = bison)
+ang_fit
+```
+
+A summary provides parameter estimates and associated inference information.
+
+```{r angular-summary}
+summary(ang_fit)
+```
+
+Diagnostic plots help assess the adequacy of the model by visualizing residuals
+and fitted directions.
+
+```{r angular-plot, fig.width=7, fig.height=6}
+plot(ang_fit)
+```
+
+# Consensus regression model
+
+The consensus model extends the angular regression framework by explicitly
+modelling the concentration parameter. The following example fits a consensus
+model using the same predictors.
+
+```{r consensus-fit}
+cons_fit <- consensus(y.dir ~ y.prec + y.prec2, data = bison)
+cons_fit
+```
+
+You can inspect the estimated parameters and goodness-of-fit criteria via the
+summary method.
+
+```{r consensus-summary}
+summary(cons_fit)
+```
+
+For a more detailed diagnostic assessment, the plotting method provides a suite
+of charts similar to those available for linear models.
+
+```{r consensus-plot, fig.width=7, fig.height=6}
+plot(cons_fit)
+```
+
+# Additional models and utilities
+
+Besides the angular and consensus models, the package exposes additional
+regression frameworks such as the decentered predictor model, Presnell model,
+and mean direction model. Refer to the function documentation for these
+methods for more examples (`?decentredPredictorModel`, `?presnellModel`,
+etc.).
+
+# Session information
+
+```{r session-info}
+sessionInfo()
+```


### PR DESCRIPTION
## Summary
- update the angular regression example to demonstrate fitting the model with the package's bison data
- add an example for the consensus model that mirrors the angular workflow with bison predictors
- create an introductory vignette that walks through fitting and diagnosing the angular and consensus models

## Testing
- not run (R tooling unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dafb7f2ad8832288dd0fd0b0342e73