### PR TITLE
Fix Rd documentation warnings and internal example

### DIFF
--- a/R/pick_reference_angle.r
+++ b/R/pick_reference_angle.r
@@ -2,7 +2,7 @@
 # Utilities
 # ======================================================================
 
-#' Safe infix "a %||% b": returns a if not NULL, otherwise b
+#' Safe infix \code{a \%||\% b}: returns \code{a} if not \code{NULL}, otherwise \code{b}
 #' @noRd
 `%||%` <- function(a, b) if (!is.null(a)) a else b
 
@@ -13,10 +13,15 @@
 
 #' Extract unique angle names (left of "x:z"), preserving first appearance order
 #' @noRd
-#'
+#' 
 #' Example:
 #'   y ~ x.meadow + x.meadow:z.meadow + x.gap + x.gap:z.gap
 #' -> c("x.meadow","x.gap")
+#'
+#' @examples
+#' CircularRegression:::.extract_angles_from_formula(
+#'   y ~ x.meadow + x.meadow:z.meadow + x.gap + x.gap:z.gap
+#' )
 .extract_angles_from_formula <- function(formula) {
   tl <- attr(terms(formula), "term.labels")
   if (length(tl) == 0) return(character(0))
@@ -28,11 +33,11 @@
   ang[!duplicated(ang)]
 }
 
-#' Build an angular formula with ref(angle_ref) for the chosen reference angle
+#' Build an angular formula with \code{ref(angle_ref)} for the chosen reference angle
 #' @noRd
-#'
+#' 
 #' Only the left symbol of any "x:z" pair is considered an angle. The reference
-#' term gets rewritten as ref(x).
+#' term gets rewritten as \code{ref(x)}.
 .make_angular_formula_with_ref <- function(formula, ref_name) {
   y <- deparse(formula[[2]])
   tl <- attr(terms(formula), "term.labels")
@@ -57,7 +62,7 @@
 # Helpers: extraction from consensus() fit
 # ======================================================================
 
-#' Extract beta (scale-free) from a consensus() fit object, robustly
+#' Extract beta (scale-free) from a \code{consensus()} fit object, robustly
 #' @noRd
 .extract_beta_consensus <- function(fit) {
   # try coef() first
@@ -78,10 +83,10 @@
   stop("Could not extract beta coefficients from consensus fit object.")
 }
 
-#' Extract kappa table (estimate, sd) from a consensus() fit object
+#' Extract kappa table (estimate, sd) from a \code{consensus()} fit object
 #'
-#' Returns a data.frame with columns "estimate" and "sd". Row names are made
-#' unique to avoid duplicate 'row.names' errors.
+#' Returns a data.frame with columns \code{estimate} and \code{sd}. Row names
+#' are made unique to avoid duplicate \code{row.names} errors.
 #' @noRd
 .extract_kappa_table <- function(fit, angle_names = NULL) {
   # Preferred path: fit$parameters already shaped like a table
@@ -137,7 +142,7 @@
   )
 }
 
-#' Add the beta_ref = 1 row (sd = 0) on top of a 2-column beta table
+#' Add the beta reference (estimate = 1) row on top of a 2-column beta table
 #' @noRd
 .add_beta1_row <- function(beta_tab, ref_name, put_first = TRUE) {
   beta_tab <- beta_tab[, c("estimate", "sd"), drop = FALSE]
@@ -162,13 +167,13 @@
 #'   (3) rescales beta so that beta_ref = 1,
 #'   (4) returns kappa (estimate, sd) as `parameters` and beta (estimate, sd) as `parambeta`,
 #'       with the first beta_ref row added (estimate=1, sd=0),
-#'   (5) optionally returns an `angular_formula` where the reference angle is written `ref(angle)`.
+#'   (5) optionally returns an \code{angular_formula} where the reference angle is written \code{ref(angle)}.
 #'
 #' @param formula A formula like y ~ x1 + x1:z1 + x2 + x2:z2 + ...
 #'                The left symbol of any "x:z" term is treated as an angular predictor.
 #' @param data A data.frame with response y, angular predictors x_j and positive variables z_j
 #' @param tie_method How to break ties if multiple |beta| are equal: "first" or "random"
-#' @param build_angular_formula If TRUE, also returns a formula ready for angular() with ref(angle)
+#' @param build_angular_formula If TRUE, also returns a formula ready for \code{angular()} with \code{ref(angle)}
 #' @param ... Additional arguments passed to consensus()
 #'
 #' @return A list with:
@@ -178,7 +183,7 @@
 #'   - beta_ref1: beta rescaled so that beta[ref] = 1
 #'   - parameters: data.frame (kappa estimate, sd)
 #'   - parambeta:  data.frame (beta estimate, sd) with beta_ref added on the first row (sd = 0)
-#'   - angular_formula (optional): formula with ref(angle_ref) ready for angular()
+#'   - angular_formula (optional): formula with \code{ref(angle_ref)} ready for \code{angular()}
 #' @export
 pick_reference_angle <- function(
   formula,

--- a/man/dot-add_beta1_row.Rd
+++ b/man/dot-add_beta1_row.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/pick_reference_angle.r
 \name{.add_beta1_row}
 \alias{.add_beta1_row}
-\title{Add the beta\_ref = 1 row (sd = 0) on top of a 2-column beta table}
+\title{Add the beta reference (estimate = 1) row on top of a 2-column beta table}
 \usage{
 .add_beta1_row(beta_tab, ref_name, put_first = TRUE)
 }
 \arguments{
-  \item{beta_tab}{A data frame containing at least the columns \\code{estimate} and \\code{sd}.}
-  \item{ref_name}{Name to use for the reference row. Defaults to ``ref`` when \\code{NULL}.}
+  \item{beta_tab}{A data frame containing at least the columns \code{estimate} and \code{sd}.}
+  \item{ref_name}{Name to use for the reference row. Defaults to \code{"ref"} when \code{NULL}.}
   \item{put_first}{Logical flag indicating whether the reference row should be placed first.}
 }
 \value{
 A data frame with the reference row inserted and unique row names.
 }
 \description{
-Add the beta\_ref = 1 row (sd = 0) on top of a 2-column beta table.
+Add the beta reference (estimate = 1) row on top of a 2-column beta table.
 }
 \keyword{internal}

--- a/man/dot-extract_angles_from_formula.Rd
+++ b/man/dot-extract_angles_from_formula.Rd
@@ -2,21 +2,21 @@
 % Please edit documentation in R/pick_reference_angle.r
 \name{.extract_angles_from_formula}
 \alias{.extract_angles_from_formula}
-\title{Extract unique angle names (left of "x:z"), preserving first appearance order}
+\title{Extract unique angle names (left of \code{x:z}), preserving first appearance order}
 \usage{
 .extract_angles_from_formula(formula)
 }
 \arguments{
-  \item{formula}{A model formula whose terms may contain ``angle:covariate`` products.}
+  \item{formula}{A model formula whose terms may contain \code{angle:covariate} products.}
 }
 \value{
 A character vector of unique angle names in the order they first appear.
 }
 \description{
-Extract unique angle names (left of ``x:z``), preserving first appearance order.
+Extract unique angle names (left of \code{x:z}), preserving first appearance order.
 }
 \examples{
 # Example usage
-.extract_angles_from_formula(y ~ x.meadow + x.meadow:z.meadow + x.gap + x.gap:z.gap)
+CircularRegression:::.extract_angles_from_formula(y ~ x.meadow + x.meadow:z.meadow + x.gap + x.gap:z.gap)
 }
 \keyword{internal}

--- a/man/dot-extract_beta_consensus.Rd
+++ b/man/dot-extract_beta_consensus.Rd
@@ -2,17 +2,17 @@
 % Please edit documentation in R/pick_reference_angle.r
 \name{.extract_beta_consensus}
 \alias{.extract_beta_consensus}
-\title{Extract beta (scale-free) from a consensus() fit object, robustly}
+\title{Extract beta (scale-free) from a \code{consensus()} fit object, robustly}
 \usage{
 .extract_beta_consensus(fit)
 }
 \arguments{
-  \item{fit}{A fitted model returned by \\code{consensus()}.}
+  \item{fit}{A fitted model returned by \code{consensus()}.}
 }
 \value{
 A numeric vector of beta coefficients extracted from the fit.
 }
 \description{
-Extract beta (scale-free) from a consensus() fit object, robustly.
+Extract beta (scale-free) from a \code{consensus()} fit object, robustly.
 }
 \keyword{internal}

--- a/man/dot-extract_kappa_table.Rd
+++ b/man/dot-extract_kappa_table.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/pick_reference_angle.r
 \name{.extract_kappa_table}
 \alias{.extract_kappa_table}
-\title{Extract kappa table (estimate, sd) from a consensus() fit object}
+\title{Extract kappa table (estimate, sd) from a \code{consensus()} fit object}
 \usage{
 .extract_kappa_table(fit, angle_names = NULL)
 }
 \arguments{
-  \item{fit}{A fitted model returned by \\code{consensus()}.}
+  \item{fit}{A fitted model returned by \code{consensus()}.}
   \item{angle_names}{Optional character vector used to label the rows of the kappa table.}
 }
 \value{
-A data frame with columns \\code{estimate} and \\code{sd} containing kappa summaries.
+A data frame with columns \code{estimate} and \code{sd} containing kappa summaries.
 }
 \description{
-Returns a data frame with columns ``estimate`` and ``sd``. Row names are made
-unique to avoid duplicate ``row.names`` errors.
+Returns a data frame with columns \code{estimate} and \code{sd}. Row names are made
+unique to avoid duplicate \code{row.names} errors.
 }
 \keyword{internal}

--- a/man/dot-make_angular_formula_with_ref.Rd
+++ b/man/dot-make_angular_formula_with_ref.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/pick_reference_angle.r
 \name{.make_angular_formula_with_ref}
 \alias{.make_angular_formula_with_ref}
-\title{Build an angular formula with ref(angle_ref) for the chosen reference angle}
+\title{Build an angular formula with \code{ref(angle_ref)} for the chosen reference angle}
 \usage{
 .make_angular_formula_with_ref(formula, ref_name)
 }
 \arguments{
   \item{formula}{A model formula that may contain angle and covariate interactions.}
-  \item{ref_name}{Name of the angle to promote to \\code{ref(angle)} in the output formula.}
+  \item{ref_name}{Name of the angle to promote to \code{ref(angle)} in the output formula.}
 }
 \value{
-An updated formula where the chosen reference angle appears as \\code{ref(angle)}.
+An updated formula where the chosen reference angle appears as \code{ref(angle)}.
 }
 \description{
 Only the left symbol of any "x:z" pair is considered an angle. The reference
-term gets rewritten as ref(x).
+term gets rewritten as \code{ref(x)}.
 }
 \keyword{internal}

--- a/man/grapes-or-or-grapes.Rd
+++ b/man/grapes-or-or-grapes.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/pick_reference_angle.r
 \name{grapes-or-or-grapes}
 \alias{\%||\%}
-\title{Safe infix ``a \%||\% b``: returns \\code{a} if not \\code{NULL}, otherwise \\code{b}}
+\title{Safe infix \code{a \%||\% b}: returns \code{a} if not \code{NULL}, otherwise \code{b}}
 \usage{
 a \%||\% b
 }
 \arguments{
-  \item{a}{Primary value to return when it is not \\code{NULL}.}
-  \item{b}{Fallback value returned when \\code{a} is \\code{NULL}.}
+  \item{a}{Primary value to return when it is not \code{NULL}.}
+  \item{b}{Fallback value returned when \code{a} is \code{NULL}.}
 }
 \value{
-The value of \\code{a} when it is not \\code{NULL}; otherwise the value of \\code{b}.
+The value of \code{a} when it is not \code{NULL}; otherwise the value of \code{b}.
 }
 \description{
-Safe infix ``a \%||\% b``: returns \\code{a} if not \\code{NULL}, otherwise \\code{b}.
+Safe infix \code{a \%||\% b}: returns \code{a} if not \code{NULL}, otherwise \code{b}.
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary
- revise internal helper documentation to use appropriate `\code{}` markup and avoid Rd brace warnings
- update the `.extract_angles_from_formula()` example to reference the internal helper via triple-colon so Rd examples run

## Testing
- not run (Rscript unavailable in container)


------
